### PR TITLE
Set compilation target to ES2020 (match previous behavior)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
       "lib": ["dom", "ES2017"],
       "esModuleInterop": true,
       "module": "ESNext",
-      "target": "ES5",
+      "target": "ES2020",
       "strictPropertyInitialization": false,
       "strict": true,
       "rootDir": "src",


### PR DESCRIPTION
Up to version 0.3.2 the code was transpiled down to at least ES2020 as seen in https://www.npmjs.com/package/flyter/v/0.3.2?activeTab=code

Somehow parcel was not respecting tsconfig target option

I started from ES2015 increasing target. ES2020 is the minimum to get same behavior as before because of Optional Chaining Operator (introduced in ES2020) usage in buildInstance method